### PR TITLE
new: support Yandex's side states

### DIFF
--- a/aioalice/types/alice_request.py
+++ b/aioalice/types/alice_request.py
@@ -1,5 +1,5 @@
-from attr import attrs, attrib
 from aiohttp.web import Request as WebRequest
+from attr import attrs, attrib
 
 from aioalice.types import (
     AliceObject,
@@ -23,32 +23,43 @@ class AliceRequest(AliceObject):
     session = attrib(converter=ensure_cls(Session))
     version = attrib(type=str)
 
-    def _response(self, response):
+    def _response(self, response, session_state=None, user_state_update=None, application_state=None):
         return AliceResponse(
             response=response,
             session=self.session.base,
+            session_state=session_state or {},
+            user_state_update=user_state_update or {},
+            application_state=application_state or {},
             version=self.version,
         )
 
-    def response(self, responose_or_text, **kwargs):
+    def response(self, response_or_text, session_state=None, user_state_update=None, application_state=None, **kwargs):
         """
         Generate response
 
-        :param responose_or_text: Response or Response's text:
-            if responose_or_text is not an instance of Response,
+        :param response_or_text: Response or Response's text:
+            if response_or_text is not an instance of Response,
             it is passed to the Response initialisator with kwargs.
             Otherwise it is used as a Response
 
         :param kwargs: tts, card, buttons, end_session for Response
-            NOTE: if you want to pass card, concider using one of
+            NOTE: if you want to pass card, consider using one of
               these methods: response_big_image, response_items_list
+
+        :param session_state: Session's state
+        :param user_state_update: User's state
+        :param application_state: Application's state
+            Allows to store data on Yandex's side
+            Read more: https://yandex.ru/dev/dialogs/alice/doc/session-persistence.html
+
         :return: AliceResponse
         """
-        if not isinstance(responose_or_text, Response):
-            responose_or_text = Response(responose_or_text, **kwargs)
-        return self._response(responose_or_text)
+        if not isinstance(response_or_text, Response):
+            response_or_text = Response(response_or_text, **kwargs)
+        return self._response(response_or_text, session_state, user_state_update, application_state)
 
-    def response_big_image(self, text, image_id, title, description, button=None, **kwargs):
+    def response_big_image(self, text, image_id, title, description, button=None,
+                           session_state=None, user_state_update=None, application_state=None, **kwargs):
         """
         Generate response with Big Image card
 
@@ -57,6 +68,11 @@ class AliceRequest(AliceObject):
         :param title: Image's title for BigImage Card
         :param description: Image's description for BigImage Card
         :param button: Image's button for BigImage Card
+        :param session_state: Session's state
+        :param user_state_update: User's state
+        :param application_state: Application's state
+            Allows to store data on Yandex's side
+            Read more: https://yandex.ru/dev/dialogs/alice/doc/session-persistence.html
         :param kwargs: tts, buttons, end_session for Response
         :return: AliceResponse
         """
@@ -65,10 +81,12 @@ class AliceRequest(AliceObject):
                 text,
                 card=Card.big_image(image_id, title, description, button),
                 **kwargs,
-            )
+            ),
+            session_state, user_state_update, application_state
         )
 
-    def response_items_list(self, text, header, items, footer=None, **kwargs):
+    def response_items_list(self, text, header, items, footer=None,
+                            session_state=None, user_state_update=None, application_state=None, **kwargs):
         """
         Generate response with Items List card
 
@@ -76,6 +94,11 @@ class AliceRequest(AliceObject):
         :param header: Card's header
         :param items: Card's items - list of `Image` objects
         :param footer: Card's footer
+        :param session_state: Session's state
+        :param user_state_update: User's state
+        :param application_state: Application's state
+            Allows to store data on Yandex's side
+            Read more: https://yandex.ru/dev/dialogs/alice/doc/session-persistence.html
         :param kwargs: tts, buttons, end_session for Response
         :return: AliceResponse
         """
@@ -84,5 +107,6 @@ class AliceRequest(AliceObject):
                 text,
                 card=Card.items_list(header, items, footer),
                 **kwargs,
-            )
+            ),
+            session_state, user_state_update, application_state
         )

--- a/aioalice/types/alice_response.py
+++ b/aioalice/types/alice_response.py
@@ -10,4 +10,7 @@ class AliceResponse(AliceObject):
 
     response = attrib(converter=ensure_cls(Response))
     session = attrib(converter=ensure_cls(BaseSession))
+    session_state = attrib(type=dict)
+    user_state_update = attrib(type=dict)
+    application_state = attrib(type=dict)
     version = attrib(type=str)


### PR DESCRIPTION
API Яндекс Диалогов позволяет сохранять данные внутри сессии навыка, а если пользователь авторизован на поверхности, где работает навык, — то и между сессиями.

https://yandex.ru/dev/dialogs/alice/doc/session-persistence.html

Протестировано на личном боте через `pip install -e`. Проверил с и без настройки "Хранилище" в настройках навыка.

Вот скриншот из официальной тестовой тулзы:
<img width="563" alt="Screenshot 2022-04-10 at 15 15 32" src="https://user-images.githubusercontent.com/6163085/162624278-a490403f-4ba2-489e-911f-a4ab88ed44c3.png">


Если есть пожелания по реализации, то код могу изменить.